### PR TITLE
Use the term "extension" in cloak.yaml and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,40 +81,40 @@ TODO: document more, but the idea here is that you can also write your own `main
 
 - A (slightly outdated) example of this can be found in `cmd/demo/main.go`
 
-### Creating a new Typescript action
+### Creating a new extension in Typescript
 
 TODO: automate and simplify the below
 
 TODO: add instructions for client stub generation (these instructions work w/ raw graphql queries right now)
 
-Say we are creating a new Typescript package called `foo` that will have a single action `bar`.
+Say we are creating a new extension, written in Typescript, called `foo` that will have a single action `bar`.
 
-1. Setup the package configuration
-   1. Copy the existing `yarn` package to a new directory for the new package:
+1. Setup the extension configuration
+   1. Copy the existing `yarn` extension to a new directory for the new extension:
       - `cp -r examples/yarn examples/foo`
    1. `cd examples/foo`
    1. `rm -rf app node_modules yarn.lock`
    1. Open `Dockerfile` and change occurences of `examples/yarn` to `examples/foo`
    1. Open `package.json`, replace occurences of `dagger-yarn` with `foo`
    1. Open `schema.graphql`, replace the existing `build`, `test` and `deploy` fields under `Query` with one field per action you want to implement
-      - This is where the schema for the actions in your package is configured. Feel free to add more complex output/input types as needed
+      - This is where the schema for the actions in your extension is configured. Feel free to add more complex output/input types as needed
       - If you want `foo` to just have a single action `bar`, you just need a field for `bar` (with appropriate input and output types).
    1. Open up `cloak.yaml`
-      - This is where you declare your own package in addition to dependencies of your package. Declaring packages here makes them available to be called by your action implementation in addition to telling cloak how to build them.
-      - Packages are declared by specifying how they are built. Currently, we just use Dockerfiles for everything, but in theory this should be much more flexible.
-      - Replacing the existing `yarn` key under `actions` with `foo`; similarly change `examples/yarn/Dockerfile` to `examples/foo/Dockerfile`
-      - Add similar entries for each of the packages you want to be able to call from your actions. They all follow the same format right now
-      - The only package you don't need to declare a dependency on is `core`, it's inherently always a dep
+      - This is where you declare your extension, and other extensions that it depends on. All extensions declared in this file will be built, loaded, and available to be called from your own extension.
+      - Currently, cloak builds extensions by looking for a Dockerfile in the extension source directory. In the future we will offer more flexibility in how extensions can be built.
+      - Replace the existing `yarn` key under `extensions` with `foo`; similarly change `examples/yarn/Dockerfile` to `examples/foo/Dockerfile`
+      - Add similar entries for each of the extensions you want to be able to call from your extensions. They all follow the same format right now
+      - You don't need to declare `core` as a dependency: it is built-in and always available to all extensions.
 1. Implement your action by editing `index.ts`
    - Replace each of the existing `Script` field under `const resolver` with an implementation for your action (or add multiple fields if implementing multiple actions).
    - The `args` parameter is an object with a field for each of the input args to your action (as defined in `schema.graphql`
    - You should use `FSID` when accepting a filesystem as an input
 
-### Creating a new Go package
+### Creating a new extension in Go
 
-Say we are creating a new Go package called `foo` that will have a single action `bar`.
+Say we are creating a new Dagger extension, written in Go, called `foo` that will have a single action `bar`.
 
-1. Setup the package configuration
+1. Setup the extension configuration
    1. Starting from the root of the cloak repo, make a new directory for your action:
       - `mkdir -p examples/foo`
    1. `cd examples/foo`
@@ -123,14 +123,15 @@ Say we are creating a new Go package called `foo` that will have a single action
       - Open `Dockerfile` and change occurences of `examples/alpine` to `examples/foo`
       - TODO: this is boilerplate that will go away soon
    1. Open `schema.graphql`, replace the existing `build` field under `Query` with one field per action you want to implement
-      - This is where the schema for the actions in your package is configured. Feel free to add more complex output/input types as needed
+      - This is where the schema for the actions in your extension is configured. Feel free to add more complex output/input types as needed
       - If you want `foo` to just have a single action `bar`, you just need a field for `bar` (with appropriate input and output types).
    1. Open up `cloak.yaml`
-      - This is where you declare your own package in addition to dependencies of your package. Declaring packages here makes them available to be called by your action implementation in addition to telling cloak how to build them.
-      - Packages are declared by specifying how they are built. Currently, we just use Dockerfiles for everything, but in theory this should be much more flexible.
-      - Replacing the existing `alpine` key under `actions` with `foo`; similarly change `examples/alpine/Dockerfile` to `examples/foo/Dockerfile`
-      - Add similar entries for each of the packages you want to be able to call from your actions. They all follow the same format right now
-      - The only package you don't need to declare a dependency on is `core`, it's inherently always a dep
+      - This is where you declare your extension, and other extensions that it depends on. All extensions declared in this file will be built, loaded, and available to be called from your own extension.
+      - Currently, cloak builds extensions by looking for a Dockerfile in the extension source directory. In the future we will offer more flexibility in how extensions can be built.
+      - Replace the existing `alpine` key under `extensions` with `foo`; similarly change `examples/alpine/Dockerfile` to `examples/foo/Dockerfile`
+      - Add similar entries for each of the extensions you want to be able to call from your actions. They all follow the same format right now
+      - You don't need to declare `core` as a dependency: it is built-in and always available to all extensions.
+      
 1. Generate client stubs and implementation stubs
    - From `examples/foo`, run `cloak generate --output-dir=. --sdk=go`
    - Now you should see client stubs for each of your dependencies under `gen/<pkgname>` in addition to helpers for your implementation under `gen/foo`

--- a/cloak.yaml
+++ b/cloak.yaml
@@ -1,4 +1,4 @@
-actions:
+extensions:
   alpine:
     local: examples/alpine
   yarn:

--- a/cmd/cloak/config/config.go
+++ b/cmd/cloak/config/config.go
@@ -14,12 +14,12 @@ import (
 )
 
 type Config struct {
-	Path    string             `yaml:"-,omitempty"`
-	Actions map[string]*Action `yaml:"actions,omitempty"`
-	Context string             `yaml:"context,omitempty"`
+	Path       string                `yaml:"-,omitempty"`
+	Extensions map[string]*Extension `yaml:"extensions,omitempty"`
+	Context    string                `yaml:"context,omitempty"`
 }
 
-type Action struct {
+type Extension struct {
 	Local      string `yaml:"local,omitempty"`
 	Image      string `yaml:"image,omitempty"`
 	Context    string `yaml:"context,omitempty"`
@@ -27,11 +27,11 @@ type Action struct {
 	operations string
 }
 
-func (a *Action) GetSchema() string {
+func (a *Extension) GetSchema() string {
 	return a.schema
 }
 
-func (a *Action) GetOperations() string {
+func (a *Extension) GetOperations() string {
 	return a.operations
 }
 
@@ -45,21 +45,21 @@ func ParseFile(f string) (*Config, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, err
 	}
-	if cfg.Actions == nil {
-		cfg.Actions = make(map[string]*Action)
+	if cfg.Extensions == nil {
+		cfg.Extensions = make(map[string]*Extension)
 	}
 
-	for _, action := range cfg.Actions {
-		if action.Local != "" {
-			if action.Context == "" {
-				action.Context = cfg.Context
+	for _, ext := range cfg.Extensions {
+		if ext.Local != "" {
+			if ext.Context == "" {
+				ext.Context = cfg.Context
 			}
-			action.Context = filepath.Join(filepath.Dir(f), action.Context)
-			action.Local = filepath.Join(cfg.Context, action.Local)
+			ext.Context = filepath.Join(filepath.Dir(f), ext.Context)
+			ext.Local = filepath.Join(cfg.Context, ext.Local)
 		}
 	}
 	// implicitly include core in every import
-	cfg.Actions["core"] = &Action{}
+	cfg.Extensions["core"] = &Extension{}
 
 	loaded, err := yaml.Marshal(&cfg)
 	if err != nil {
@@ -72,20 +72,20 @@ func ParseFile(f string) (*Config, error) {
 
 func (c *Config) LocalDirs() map[string]string {
 	localDirs := make(map[string]string)
-	for _, action := range c.Actions {
-		if action.Local == "" {
+	for _, ext := range c.Extensions {
+		if ext.Local == "" {
 			continue
 		}
-		localDirs[action.Context] = action.Context
+		localDirs[ext.Context] = ext.Context
 	}
 	return localDirs
 }
 
 func (c *Config) LoadExtensions(ctx context.Context, localDirs map[string]dagger.FSID) error {
 	var eg errgroup.Group
-	for name, action := range c.Actions {
+	for name, ext := range c.Extensions {
 		name := name
-		action := action
+		ext := ext
 		eg.Go(func() error {
 			switch {
 			case name == "core":
@@ -93,16 +93,16 @@ func (c *Config) LoadExtensions(ctx context.Context, localDirs map[string]dagger
 				if err != nil {
 					return fmt.Errorf("error importing %s: %w", name, err)
 				}
-				action.schema = schema
-				action.operations = operations
-			case action.Local != "":
-				dockerfile := path.Join(action.Local, "Dockerfile")
-				schema, operations, err := importLocal(ctx, name, localDirs[action.Context], dockerfile)
+				ext.schema = schema
+				ext.operations = operations
+			case ext.Local != "":
+				dockerfile := path.Join(ext.Local, "Dockerfile")
+				schema, operations, err := importLocal(ctx, name, localDirs[ext.Context], dockerfile)
 				if err != nil {
 					return fmt.Errorf("error importing %s: %w", name, err)
 				}
-				action.schema = schema
-				action.operations = operations
+				ext.schema = schema
+				ext.operations = operations
 			}
 			return nil
 		})

--- a/cmd/cloak/generate.go
+++ b/cmd/cloak/generate.go
@@ -56,7 +56,7 @@ func Generate(cmd *cobra.Command, args []string) {
 		if err := cfg.LoadExtensions(ctx, localDirs); err != nil {
 			return err
 		}
-		for name, act := range cfg.Actions {
+		for name, ext := range cfg.Extensions {
 			subdir := filepath.Join(generateOutputDir, "gen", name)
 			if err := os.MkdirAll(subdir, 0755); err != nil {
 				return err
@@ -67,7 +67,7 @@ func Generate(cmd *cobra.Command, args []string) {
 			schemaPath := filepath.Join(subdir, "schema.graphql")
 
 			// TODO: ugly hack to make each schema/operation work independently when referencing core types
-			fullSchema := act.GetSchema()
+			fullSchema := ext.GetSchema()
 			if name != "core" {
 				fullSchema = coreschema.Schema + "\n\n" + fullSchema
 			}
@@ -76,7 +76,7 @@ func Generate(cmd *cobra.Command, args []string) {
 				return err
 			}
 			operationsPath := filepath.Join(subdir, "operations.graphql")
-			if err := os.WriteFile(operationsPath, []byte(act.GetOperations()), 0644); err != nil {
+			if err := os.WriteFile(operationsPath, []byte(ext.GetOperations()), 0644); err != nil {
 				return err
 			}
 

--- a/examples/alpine/cloak.yaml
+++ b/examples/alpine/cloak.yaml
@@ -1,4 +1,4 @@
-actions:
+extensions:
   alpine:
     local: examples/alpine
 context: ../..

--- a/examples/netlify/go/cloak.yaml
+++ b/examples/netlify/go/cloak.yaml
@@ -1,4 +1,4 @@
-actions:
+extensions:
   netlify:
     local: examples/netlify/go
 context: ../../..

--- a/examples/netlify/ts/cloak.yaml
+++ b/examples/netlify/ts/cloak.yaml
@@ -1,4 +1,4 @@
-actions:
+extensions:
   netlify:
     local: examples/netlify/ts
 context: ../../..

--- a/examples/queries/cloak.yaml
+++ b/examples/queries/cloak.yaml
@@ -1,4 +1,4 @@
-actions:
+extensions:
   alpine:
     local: examples/alpine
   # yarn:

--- a/examples/todoapp/go/cloak.yaml
+++ b/examples/todoapp/go/cloak.yaml
@@ -1,4 +1,4 @@
-actions:
+extensions:
   alpine:
     local: examples/alpine
   yarn:

--- a/examples/todoapp/ts/cloak.yaml
+++ b/examples/todoapp/ts/cloak.yaml
@@ -1,4 +1,4 @@
-actions:
+extensions:
   alpine:
     local: examples/alpine
   yarn:

--- a/examples/yarn/cloak.yaml
+++ b/examples/yarn/cloak.yaml
@@ -1,4 +1,4 @@
-actions:
+extensions:
   alpine:
     local: examples/alpine
   yarn:


### PR DESCRIPTION
This introduces two terminology changes:

* Use "extensions" instead of "actions" in `cloak.yaml` (more accurate)
* Use "extension" instead of "package" in README (more consistent)

In a follow-up PR I will change "package" to "extension" in the graphql API.