### PR TITLE
core/exec: hide shim from build logs and error messages

### DIFF
--- a/core/shim/shim.go
+++ b/core/shim/shim.go
@@ -19,6 +19,8 @@ var cmd embed.FS
 
 var state llb.State
 
+const Path = "/_shim"
+
 func init() {
 	entries, err := fs.ReadDir(cmd, "cmd")
 	if err != nil {


### PR DESCRIPTION
Fixes dagger/dagger#3101

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>
