### PR TITLE
feat: use a code first approach for the Go SDK

### DIFF
--- a/examples/go_code_first/types.go
+++ b/examples/go_code_first/types.go
@@ -79,9 +79,14 @@ func Schema(h any) (string, error) {
 	if t.Kind() != reflect.Pointer {
 		name = strings.ToLower(t.Name())
 		pt = reflect.PointerTo(t)
-		methods = append(methods, getMethods(pt)...)
-		for _, v := range methods {
+		tMethods := getMethods(pt)
+		for _, v := range tMethods {
+			_, ok := methodMap[v.Name]
+			if ok {
+				continue
+			}
 			methodMap[v.Name] = struct{}{}
+			methods = append(methods, v)
 		}
 	}
 

--- a/examples/go_code_first/types.go
+++ b/examples/go_code_first/types.go
@@ -21,37 +21,87 @@ func (h *Hugo) Generate(ctx context.Context, source FS) FS {
 	return FS{}
 }
 
-func Schema(h any) (string, error) {
-	t := reflect.TypeOf(h)
-	pt := reflect.PointerTo(t)
-	if t.Kind() != reflect.Pointer {
-		log.Println("ptr:", false)
-		t = reflect.TypeOf(&h)
-	}
-	if t.Kind() != reflect.Pointer {
-		log.Println("ptr2:", false)
-		t = reflect.TypeOf(&h)
-	}
-	_ = pt
-	name := strings.ToLower(t.Name())
+type Method struct {
+	Name    string
+	ArgsIn  []string
+	ArgsOut []string
+}
 
-	var methods []string
+func getMethods(t reflect.Type) []Method {
+	var methods []Method
 	for i := 0; i < t.NumMethod(); i++ {
 		m := t.Method(i)
 		mName := strings.ToLower(m.Name)
-		methods = append(methods, mName)
+		// args
+		mType := m.Type
+		var argsIn []string
+		for j := 0; j < mType.NumIn(); j++ {
+			arg := mType.In(j)
+			argName := strings.ToLower(arg.Name())
+			argsIn = append(argsIn, argName)
+		}
+
+		var argsOut []string
+		for j := 0; j < mType.NumOut(); j++ {
+			arg := mType.Out(j)
+			argName := strings.ToLower(arg.Name())
+			argsOut = append(argsOut, argName)
+		}
+		methods = append(methods, Method{mName, argsIn, argsOut})
+	}
+	return methods
+}
+
+func Schema(h any) (string, error) {
+	t := reflect.TypeOf(h)
+
+	methodMap := map[string]struct{}{}
+	methods := getMethods(t)
+	for _, v := range methods {
+		methodMap[v.Name] = struct{}{}
+	}
+
+	var name string
+	var pt reflect.Type
+	if t.Kind() != reflect.Pointer {
+		log.Println("ptr:", false)
+		name = strings.ToLower(t.Name())
+		pt = reflect.PointerTo(t)
+		methods = append(methods, getMethods(pt)...)
+		for _, v := range methods {
+			methodMap[v.Name] = struct{}{}
+		}
+	}
+
+	_ = pt
+	//name := strings.ToLower(t.Name())
+
+	var ptt reflect.Type
+	if t.Kind() == reflect.Pointer {
+		log.Println("ptr:", true)
+		ptt = t
+		name = strings.ToLower(t.Elem().Name())
+		pttMethods := getMethods(ptt)
+		for _, v := range pttMethods {
+			_, ok := methodMap[v.Name]
+			if ok {
+				continue
+			}
+			methodMap[v.Name] = struct{}{}
+			methods = append(methods, v)
+		}
 	}
 
 	type method struct {
 		Name    string
-		Methods []string
+		Methods []Method
 	}
 
 	m := method{name, methods}
 	log.Println("name:", name)
-	tpl := template.Must(template.New("schema").Parse(` {{ .Name }} {
+	tpl := template.Must(template.New("schema").Funcs(template.FuncMap{"join": func(sep string, s []string) string { return strings.Join(s, sep) }}).Parse(` {{ .Name }} {
 		{{ range .Methods -}}
-		{{ . }}(/*TODO*/ src: FSID!) Filesystem!
+		{{ .Name }}( {{ join "," .ArgsIn }} ) {{join "," .ArgsOut}}
 		{{- end }}
 	}`))
 

--- a/examples/go_code_first/types.go
+++ b/examples/go_code_first/types.go
@@ -109,9 +109,9 @@ func Schema(h any) (string, error) {
 
 	m := method{name, methods}
 	log.Println("name:", name)
-	tpl := template.Must(template.New("schema").Funcs(template.FuncMap{"join": func(sep string, s []string) string { return strings.Join(s, sep) }}).Parse(` {{ .Name }} {
+	tpl := template.Must(template.New("schema").Funcs(template.FuncMap{"join": joinOut, "formatArgs": formatArgs}).Parse(` {{ .Name }} {
 		{{ range .Methods -}}
-		{{ .Name }}( {{ join "," .ArgsIn }} ) {{join "," .ArgsOut}}
+		{{ .Name }}( {{ formatArgs ", " .ArgsIn }} ) {{join ", " .ArgsOut}}
 		{{- end }}
 	}`))
 
@@ -122,4 +122,20 @@ func Schema(h any) (string, error) {
 	}
 
 	return b.String(), nil
+}
+
+func joinOut(sep string, s []string) string {
+	if len(s) < 2 {
+		return s[0]
+	}
+
+	return "(" + strings.Join(s, sep) + ")"
+}
+
+func formatArgs(sep string, s []string) string {
+	for i, v := range s {
+		// we create the arg name + arg type couple
+		s[i] = string(v[0]) + ": " + v
+	}
+	return strings.Join(s, sep)
 }

--- a/examples/go_code_first/types.go
+++ b/examples/go_code_first/types.go
@@ -1,0 +1,65 @@
+package nogen
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"reflect"
+	"strings"
+	"text/template"
+)
+
+type Hugo struct {
+}
+
+// FS should be actually part of cloak API
+type FS struct {
+	Path string
+}
+
+func (h *Hugo) Generate(ctx context.Context, source FS) FS {
+	return FS{}
+}
+
+func Schema(h any) (string, error) {
+	t := reflect.TypeOf(h)
+	pt := reflect.PointerTo(t)
+	if t.Kind() != reflect.Pointer {
+		log.Println("ptr:", false)
+		t = reflect.TypeOf(&h)
+	}
+	if t.Kind() != reflect.Pointer {
+		log.Println("ptr2:", false)
+		t = reflect.TypeOf(&h)
+	}
+	_ = pt
+	name := strings.ToLower(t.Name())
+
+	var methods []string
+	for i := 0; i < t.NumMethod(); i++ {
+		m := t.Method(i)
+		mName := strings.ToLower(m.Name)
+		methods = append(methods, mName)
+	}
+
+	type method struct {
+		Name    string
+		Methods []string
+	}
+
+	m := method{name, methods}
+	log.Println("name:", name)
+	tpl := template.Must(template.New("schema").Parse(` {{ .Name }} {
+		{{ range .Methods -}}
+		{{ . }}(/*TODO*/ src: FSID!) Filesystem!
+		{{- end }}
+	}`))
+
+	var b bytes.Buffer
+	err := tpl.Execute(&b, m)
+	if err != nil {
+		return "", err
+	}
+
+	return b.String(), nil
+}

--- a/examples/go_code_first/types_test.go
+++ b/examples/go_code_first/types_test.go
@@ -26,4 +26,33 @@ normal:
 pointer:
 	%v`, s, ps)
 	}
+
+	//t.Log(s)
+}
+
+type T struct{}
+
+func (t T) Func1(ctx context.Context, a, b int) (string, error) {
+	return "", nil
+}
+
+func (t T) MustFunc1(a, b int) string {
+	return ""
+}
+
+func ExampleSchema() {
+	t := T{}
+
+	s, err := Schema(t)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	fmt.Println(s)
+	// Output:
+	// t {
+	// 		func1(i: int, i: int): string
+	// 		mustfunc1(i: int, i: int): string
+	// }
 }

--- a/examples/go_code_first/types_test.go
+++ b/examples/go_code_first/types_test.go
@@ -1,0 +1,13 @@
+package nogen
+
+import "testing"
+
+func TestSchema(t *testing.T) {
+	h := Hugo{}
+
+	s, err := Schema(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(s)
+}

--- a/examples/go_code_first/types_test.go
+++ b/examples/go_code_first/types_test.go
@@ -1,13 +1,29 @@
 package nogen
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"log"
+	"testing"
+)
 
 func TestSchema(t *testing.T) {
-	h := &Hugo{}
+	h := Hugo{}
 
 	s, err := Schema(h)
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Log(s)
+
+	ps, err := Schema(&h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != ps {
+		t.Fatalf(`generated schema mismatch:
+normal:
+	%v
+pointer:
+	%v`, s, ps)
+	}
 }

--- a/examples/go_code_first/types_test.go
+++ b/examples/go_code_first/types_test.go
@@ -3,7 +3,7 @@ package nogen
 import "testing"
 
 func TestSchema(t *testing.T) {
-	h := Hugo{}
+	h := &Hugo{}
 
 	s, err := Schema(h)
 	if err != nil {


### PR DESCRIPTION
I believe we should remove as much codegen as possible, so here is my attempt of doing that.
As a Go coder enjoying coding in Go doesn't make me wanna learn GraphQL. As much as I don't want learn CUE if I just want to run some CI.
So for me, the Go SDK should let you code your logic in Go, and whatever GraphQL internal pipes should be handled automatically. If you get the GraphiQL for free, it's nice, but it shouldn't be required to know how to stitch graphql query in your language.

It's WIP, and we can have nice discussions on the topic here, as needed.