### PR TITLE
Prettify generated Core schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ stub/stub
 .idea
 
 node_modules
+
+# Built Binary
+cloak

--- a/core/core.schema.go
+++ b/core/core.schema.go
@@ -25,68 +25,68 @@ func (r *coreSchema) Name() string {
 
 func (r *coreSchema) Schema() string {
 	return `
-	extend type Query {
-		"Core API"
-		core: Core!
-
-		"Host API"
-		host: Host!
-	}
-
+extend type Query {
 	"Core API"
-	type Core {
-		"Fetch an OCI image"
-		image(ref: String!): Filesystem!
+	core: Core!
 
-		"Fetch a git repository"
-		git(remote: String!, ref: String): Filesystem!
-	}
+	"Host API"
+	host: Host!
+}
 
-	"Interactions with the user's host filesystem"
-	type Host {
-		"Fetch the client's workdir"
-		workdir: LocalDir!
+"Core API"
+type Core {
+	"Fetch an OCI image"
+	image(ref: String!): Filesystem!
 
-		"Fetch a client directory"
-		dir(id: String!): LocalDir!
-	}
+	"Fetch a git repository"
+	git(remote: String!, ref: String): Filesystem!
+}
 
-	"A directory on the user's host filesystem"
-	type LocalDir {
-		"Read the contents of the directory"
-		read: Filesystem!
+"Interactions with the user's host filesystem"
+type Host {
+	"Fetch the client's workdir"
+	workdir: LocalDir!
 
-		"Write the provided filesystem to the directory"
-		write(contents: FSID!): Boolean!
-	}
+	"Fetch a client directory"
+	dir(id: String!): LocalDir!
+}
+
+"A directory on the user's host filesystem"
+type LocalDir {
+	"Read the contents of the directory"
+	read: Filesystem!
+
+	"Write the provided filesystem to the directory"
+	write(contents: FSID!): Boolean!
+}
 	`
 }
 
 func (r *coreSchema) Operations() string {
 	return `
-	query Image($ref: String!) {
-		core {
-			image(ref: $ref) {
+query Image($ref: String!) {
+	core {
+		image(ref: $ref) {
+			id
+		}
+	}
+}
+query Workdir() {
+	host {
+		workdir {
+			read {
 				id
 			}
 		}
 	}
-	query Workdir() {
-		host {
-			workdir {
-				read {
-					id
-				}
-			}
+}
+query WriteWorkdir($contents: FSID!) {
+	host {
+		workdir {
+			write(contents: $contents)
 		}
 	}
-	query WriteWorkdir($contents: FSID!) {
-		host {
-			workdir {
-				write(contents: $contents)
-			}
-		}
-	}
+}
 	`
 }
 

--- a/core/dockerbuild.schema.go
+++ b/core/dockerbuild.schema.go
@@ -22,10 +22,10 @@ func (s *dockerBuildSchema) Name() string {
 
 func (s *dockerBuildSchema) Schema() string {
 	return `
-	extend type Filesystem {
-		"docker build using this filesystem as context"
-		dockerbuild(dockerfile: String): Filesystem!
-	}
+extend type Filesystem {
+	"docker build using this filesystem as context"
+	dockerbuild(dockerfile: String): Filesystem!
+}
 	`
 }
 

--- a/core/exec.schema.go
+++ b/core/exec.schema.go
@@ -63,115 +63,115 @@ func (s *execSchema) Name() string {
 
 func (s *execSchema) Schema() string {
 	return `
-	"Command execution"
-	type Exec {
-		"Modified filesystem"
-		fs: Filesystem!
+"Command execution"
+type Exec {
+	"Modified filesystem"
+	fs: Filesystem!
 
-		"stdout of the command"
-		stdout(lines: Int): String
+	"stdout of the command"
+	stdout(lines: Int): String
 
-		"stderr of the command"
-		stderr(lines: Int): String
+	"stderr of the command"
+	stderr(lines: Int): String
 
-		"Exit code of the command"
-		exitCode: Int
+	"Exit code of the command"
+	exitCode: Int
 
-		"Modified mounted filesystem"
-		mount(path: String!): Filesystem!
-	}
+	"Modified mounted filesystem"
+	mount(path: String!): Filesystem!
+}
 
-	input MountInput {
-		"filesystem to mount"
-		fs: FSID!
+input MountInput {
+	"filesystem to mount"
+	fs: FSID!
 
-		"path at which the filesystem will be mounted"
-		path: String!
-	}
+	"path at which the filesystem will be mounted"
+	path: String!
+}
 
-	input CacheMountInput {
-		"Cache mount name"
-		name: String!
+input CacheMountInput {
+	"Cache mount name"
+	name: String!
 
-		"Cache mount sharing mode (TODO: switch to enum)"
-		sharingMode: String!
+	"Cache mount sharing mode (TODO: switch to enum)"
+	sharingMode: String!
 
-		"path at which the cache will be mounted"
-		path: String!
-	}
+	"path at which the cache will be mounted"
+	path: String!
+}
 
-	input ExecInput {
-		"""
-		Command to execute
-		Example: ["echo", "hello, world!"]
-		"""
-		args: [String!]!
+input ExecInput {
+	"""
+	Command to execute
+	Example: ["echo", "hello, world!"]
+	"""
+	args: [String!]!
 
-		"Filesystem mounts"
-		mounts: [MountInput!]
+	"Filesystem mounts"
+	mounts: [MountInput!]
 
-		"Cached mounts"
-		cacheMounts: [CacheMountInput!]
+	"Cached mounts"
+	cacheMounts: [CacheMountInput!]
 
-		"Working directory"
-		workdir: String
+	"Working directory"
+	workdir: String
 
-		"Env vars"
-		env: [ExecEnvInput!]
+	"Env vars"
+	env: [ExecEnvInput!]
 
-		"Secret env vars"
-		secretEnv: [ExecSecretEnvInput!]
+	"Secret env vars"
+	secretEnv: [ExecSecretEnvInput!]
 
-		"Include the host's ssh agent socket in the exec at the provided path"
-		sshAuthSock: String
-	}
+	"Include the host's ssh agent socket in the exec at the provided path"
+	sshAuthSock: String
+}
 
-	input ExecEnvInput {
-		"Env var name"
-		name: String!
-		"Env var value"
-		value: String!
-	}
+input ExecEnvInput {
+	"Env var name"
+	name: String!
+	"Env var value"
+	value: String!
+}
 
-	input ExecSecretEnvInput {
-		"Env var name"
-		name: String!
-		"Secret env var value"
-		id: SecretID!
-	}
+input ExecSecretEnvInput {
+	"Env var name"
+	name: String!
+	"Secret env var value"
+	id: SecretID!
+}
 
-	# FIXME: broken
-	# extend type Filesystem {
-	#	"execute a command inside this filesystem"
-	# 	exec(input: ExecInput!): Exec!
-	# }
+# FIXME: broken
+# extend type Filesystem {
+#	"execute a command inside this filesystem"
+# 	exec(input: ExecInput!): Exec!
+# }
 	`
 }
 
 func (s *execSchema) Operations() string {
 	return `
-	query Exec($fsid: FSID!, $input: ExecInput!) {
-		core {
-			filesystem(id: $fsid) {
-				exec(input: $input) {
-					fs {
-						id
-					}
+query Exec($fsid: FSID!, $input: ExecInput!) {
+	core {
+		filesystem(id: $fsid) {
+			exec(input: $input) {
+				fs {
+					id
 				}
 			}
 		}
 	}
-	query ExecGetMount($fsid: FSID!, $input: ExecInput!, $getPath: String!) {
-		core {
-			filesystem(id: $fsid) {
-				exec(input: $input) {
-					mount(path: $getPath) {
-						id
-					}
+}
+query ExecGetMount($fsid: FSID!, $input: ExecInput!, $getPath: String!) {
+	core {
+		filesystem(id: $fsid) {
+			exec(input: $input) {
+				mount(path: $getPath) {
+					id
 				}
 			}
 		}
 	}
+}
 	`
 }
 

--- a/core/filesystem.schema.go
+++ b/core/filesystem.schema.go
@@ -48,34 +48,34 @@ func (s *filesystemSchema) Name() string {
 
 func (s *filesystemSchema) Schema() string {
 	return `
-	scalar FSID
+scalar FSID
 
-	"""
-	A reference to a filesystem tree.
+"""
+A reference to a filesystem tree.
 
-	For example:
-	 - The root filesystem of a container
-	 - A source code repository
-	 - A directory containing binary artifacts
+For example:
+	- The root filesystem of a container
+	- A source code repository
+	- A directory containing binary artifacts
 
-	Rule of thumb: if it fits in a tar archive, it fits in a Filesystem.
-	"""
-	type Filesystem {
-		id: FSID!
+Rule of thumb: if it fits in a tar archive, it fits in a Filesystem.
+"""
+type Filesystem {
+	id: FSID!
 
-		"read a file at path"
-		file(path: String!, lines: Int): String
+	"read a file at path"
+	file(path: String!, lines: Int): String
 
-		# FIXME: this should be in execSchema. However, removing this results in an error:
-		# failed to resolve all type definitions: [Core Query Filesystem Exec]
-		"execute a command inside this filesystem"
-		exec(input: ExecInput!): Exec!
-	}
+	# FIXME: this should be in execSchema. However, removing this results in an error:
+	# failed to resolve all type definitions: [Core Query Filesystem Exec]
+	"execute a command inside this filesystem"
+	exec(input: ExecInput!): Exec!
+}
 
-	extend type Core {
-		"Look up a filesystem by its ID"
-		filesystem(id: FSID!): Filesystem!
-	}
+extend type Core {
+	"Look up a filesystem by its ID"
+	filesystem(id: FSID!): Filesystem!
+}
 	`
 }
 

--- a/core/project.schema.go
+++ b/core/project.schema.go
@@ -37,63 +37,63 @@ func (s *projectSchema) Name() string {
 
 func (s *projectSchema) Schema() string {
 	return `
-	"A set of scripts and/or extensions"
-	type Project {
-		"name of the project"
-		name: String!
+"A set of scripts and/or extensions"
+type Project {
+	"name of the project"
+	name: String!
 
-		"schema provided by the project"
-		schema: String
+	"schema provided by the project"
+	schema: String
 
-		"operations provided by the project"
-		operations: String
+	"operations provided by the project"
+	operations: String
 
-		"extensions in this project"
-		extensions: [Extension!]!
+	"extensions in this project"
+	extensions: [Extension!]!
 
-		"scripts in this project"
-		scripts: [Script!]!
+	"scripts in this project"
+	scripts: [Script!]!
 
-		"other projects with schema this project depends on"
-		dependencies: [Project!]
+	"other projects with schema this project depends on"
+	dependencies: [Project!]
 
-		"install the project's schema"
-		install: Boolean!
-	}
+	"install the project's schema"
+	install: Boolean!
+}
 
-	"A schema extension provided by a project"
-	type Extension {
-		"path to the extension's code within the project's filesystem"
-		path: String!
+"A schema extension provided by a project"
+type Extension {
+	"path to the extension's code within the project's filesystem"
+	path: String!
 
-		"schema contributed to the project by this extension"
-		schema: String!
+	"schema contributed to the project by this extension"
+	schema: String!
 
-		"operations contributed to the project by this extension (if any)"
-		operations: String
+	"operations contributed to the project by this extension (if any)"
+	operations: String
 
-		"sdk used to generate code for and/or execute this extension"
-		sdk: String!
-	}
+	"sdk used to generate code for and/or execute this extension"
+	sdk: String!
+}
 
-	"An executable script that uses the project's dependencies and/or extensions"
-	type Script {
-		"path to the script's code within the project's filesystem"
-		path: String!
+"An executable script that uses the project's dependencies and/or extensions"
+type Script {
+	"path to the script's code within the project's filesystem"
+	path: String!
 
-		"sdk used to generate code for and/or execute this script"
-		sdk: String!
-	}
+	"sdk used to generate code for and/or execute this script"
+	sdk: String!
+}
 
-	extend type Filesystem {
-		"load a project's metadata"
-		loadProject(configPath: String!): Project!
-	}
+extend type Filesystem {
+	"load a project's metadata"
+	loadProject(configPath: String!): Project!
+}
 
-	extend type Core {
-		"Look up a project by name"
-		project(name: String!): Project!
-	}
+extend type Core {
+	"Look up a project by name"
+	project(name: String!): Project!
+}
 	`
 }
 

--- a/core/secret.schema.go
+++ b/core/secret.schema.go
@@ -47,25 +47,25 @@ func (s *secretSchema) Name() string {
 
 func (s *secretSchema) Schema() string {
 	return `
-	scalar SecretID
+scalar SecretID
 
-	extend type Core {
-		"Look up a secret by ID"
-		secret(id: SecretID!): String!
+extend type Core {
+	"Look up a secret by ID"
+	secret(id: SecretID!): String!
 
-		"Add a secret"
-		addSecret(plaintext: String!): SecretID!
-	}
+	"Add a secret"
+	addSecret(plaintext: String!): SecretID!
+}
 	`
 }
 
 func (s *secretSchema) Operations() string {
 	return `
-	query Secret($id: SecretID!) {
-		core {
-			secret(id: $id)
-		}
+query Secret($id: SecretID!) {
+	core {
+		secret(id: $id)
 	}
+}
 	`
 }
 


### PR DESCRIPTION
Signed-off-by: kpenfound <kylepenfound@pm.me>

Currently the Core schema as generated by `cloak generate` is tabbed because of how the text is committed. This leads to the `gen/core` having a leading tab for the whole file, and other `gen/*` having mixed tabs because of the combination of Core + Library.  For example:

Before: `gen/netlify/schema.graphql`
```
	scalar SecretID

	extend type Core {
		"Look up a secret by ID"
		secret(id: SecretID!): String!

		"Add a secret"
		addSecret(plaintext: String!): SecretID!
	}
	

extend type Query {
  netlify: Netlify!
}

type Netlify {
  deploy(
    contents: FSID!
    subdir: String
    siteName: String
    token: SecretID!
  ): SiteURLs!
}
```

After: `gen/netlify/schema.graphql`
```
scalar SecretID

extend type Core {
	"Look up a secret by ID"
	secret(id: SecretID!): String!

	"Add a secret"
	addSecret(plaintext: String!): SecretID!
}
	

extend type Query {
  netlify: Netlify!
}

type Netlify {
  deploy(
    contents: FSID!
    subdir: String
    siteName: String
    token: SecretID!
  ): SiteURLs!
}
```