### PR TITLE
feat: serve api at /query

### DIFF
--- a/sdk/go/dagger/client.go
+++ b/sdk/go/dagger/client.go
@@ -35,7 +35,7 @@ func Client(ctx context.Context) (graphql.Client, error) {
 	if !ok {
 		return nil, errors.New("no dagger client in context")
 	}
-	return graphql.NewClient("http://fake.invalid", client), nil
+	return graphql.NewClient("http://fake.invalid/query", client), nil
 }
 
 func WithHTTPClient(ctx context.Context, c *http.Client) context.Context {

--- a/sdk/nodejs/dagger/client.ts
+++ b/sdk/nodejs/dagger/client.ts
@@ -6,7 +6,7 @@ import { Response } from "node-fetch";
 // @ts-expect-error node-fetch doesn't exactly match the Response object, but close enough.
 global.Response = Response;
 
-export const client = new GraphQLClient("http://fake.invalid/graphql", {
+export const client = new GraphQLClient("http://fake.invalid/query", {
   fetch: buildAxiosFetch(
     axios.create({
       socketPath: "/dagger.sock",
@@ -27,7 +27,7 @@ export class Client {
 
   public async do(payload: string): Promise<any> {
     const response = await this.client.post(
-      `http://fake.invalid/graphql`,
+      `http://fake.invalid/query`,
       payload,
       { headers: { "Content-Type": "application/graphql" } }
     );

--- a/sdk/nodejs/dagger/dist/client.js
+++ b/sdk/nodejs/dagger/dist/client.js
@@ -13,7 +13,7 @@ import { GraphQLClient } from "graphql-request";
 import { Response } from "node-fetch";
 // @ts-expect-error node-fetch doesn't exactly match the Response object, but close enough.
 global.Response = Response;
-export const client = new GraphQLClient("http://fake.invalid/graphql", {
+export const client = new GraphQLClient("http://fake.invalid/query", {
     fetch: buildAxiosFetch(axios.create({
         socketPath: "/dagger.sock",
         timeout: 3600e3,
@@ -28,7 +28,7 @@ export class Client {
     }
     do(payload) {
         return __awaiter(this, void 0, void 0, function* () {
-            const response = yield this.client.post(`http://fake.invalid/graphql`, payload, { headers: { "Content-Type": "application/graphql" } });
+            const response = yield this.client.post(`http://fake.invalid/query`, payload, { headers: { "Content-Type": "application/graphql" } });
             return response;
         });
     }

--- a/sdk/nodejs/dagger/engine.ts
+++ b/sdk/nodejs/dagger/engine.ts
@@ -55,13 +55,13 @@ export class Engine {
     });
     for (let i = 0; i < 360; i++) {
       try {
-        await client.get("/");
+        await client.get("/query");
       } catch (e) {
         await new Promise((resolve) => setTimeout(resolve, 500));
       }
     }
 
-    await cb(new GraphQLClient(`http://localhost:${this.config.Port}`))
+    await cb(new GraphQLClient(`http://localhost:${this.config.Port}/query`))
       .catch(async (err) => {
         // FIXME:(sipsma) give the engine a sec to flush any progress logs on error
         // Better solution is to send SIGTERM and have a handler in cloak engine that


### PR DESCRIPTION
Rely on ServeMux to serve api on `/query` route.

Fixes dagger/dagger#3091

Signed-off-by: Guillaume de Rouville