### PR TITLE
Format paths for Linux platform containers

### DIFF
--- a/project/project.go
+++ b/project/project.go
@@ -76,21 +76,23 @@ func Load(ctx context.Context, gw bkgw.Client, platform specs.Platform, contextF
 
 	sourceSchemas := make([]router.LoadedSchema, len(cfg.Extensions))
 	for i, ext := range cfg.Extensions {
-		sdl, err := contextFS.ReadFile(ctx, gw, filepath.Join(
+		// filepath.Join and .Dir both swap file separator characters on Windows
+		sdl, err := contextFS.ReadFile(ctx, gw, filepath.ToSlash(filepath.Join(
 			filepath.Dir(configPath),
 			ext.Path,
 			schemaPath,
-		))
+		)))
 		if err != nil {
 			return nil, err
 		}
 		ext.Schema = string(sdl)
 
-		operations, err := contextFS.ReadFile(ctx, gw, filepath.Join(
+		// filepath.Join and .Dir both swap file separator characters on Windows
+		operations, err := contextFS.ReadFile(ctx, gw, filepath.ToSlash(filepath.Join(
 			filepath.Dir(configPath),
 			ext.Path,
 			operationsPath,
-		))
+		)))
 		if err != nil && !isGatewayFileNotFound(err) {
 			return nil, err
 		}
@@ -109,7 +111,7 @@ func Load(ctx context.Context, gw bkgw.Client, platform specs.Platform, contextF
 		// TODO:(sipsma) ensure only one source is specified
 		switch {
 		case dep.Local != "":
-			depConfigPath := filepath.Join(filepath.Dir(configPath), dep.Local)
+			depConfigPath := filepath.ToSlash(filepath.Join(filepath.Dir(configPath), dep.Local))
 			depSchema, err := Load(ctx, gw, platform, contextFS, depConfigPath, sshAuthSockID)
 			if err != nil {
 				return nil, err

--- a/project/sdk.go
+++ b/project/sdk.go
@@ -38,7 +38,7 @@ func goRuntime(ctx context.Context, contextFS *filesystem.Filesystem, cfgPath, s
 			Run(llb.Shlex(
 				fmt.Sprintf(
 					`go build -o /entrypoint -ldflags '-s -d -w' %s`,
-					filepath.Join(workdir, filepath.Dir(cfgPath), sourcePath),
+					filepath.ToSlash(filepath.Join(workdir, filepath.Dir(cfgPath), sourcePath)),
 				)),
 				llb.Dir(workdir),
 				llb.AddEnv("GOMODCACHE", "/root/.cache/gocache"),
@@ -64,7 +64,7 @@ func tsRuntime(ctx context.Context, contextFS *filesystem.Filesystem, cfgPath, s
 		return nil, err
 	}
 
-	ctrSrcPath := filepath.Join("/src", filepath.Dir(cfgPath), sourcePath)
+	ctrSrcPath := filepath.ToSlash(filepath.Join("/src", filepath.Dir(cfgPath), sourcePath))
 
 	addSSHKnownHosts, err := withGithubSSHKnownHosts()
 	if err != nil {
@@ -110,7 +110,7 @@ func dockerfileRuntime(ctx context.Context, contextFS *filesystem.Filesystem, cf
 
 	opts := map[string]string{
 		"platform": platforms.Format(p),
-		"filename": filepath.Join(filepath.Dir(cfgPath), sourcePath, "Dockerfile"),
+		"filename": filepath.ToSlash(filepath.Join(filepath.Dir(cfgPath), sourcePath, "Dockerfile")),
 	}
 	inputs := map[string]*pb.Definition{
 		dockerfilebuilder.DefaultLocalNameContext:    def,


### PR DESCRIPTION
This isn't a permanent solution. If `cloak` ever wants to support Windows containers, I'm not sure this will work. But, it gets me past the extension install phase so I can actually test other parts.