### PR TITLE
Update js build of engine.

### DIFF
--- a/sdk/nodejs/dagger/dist/engine.js
+++ b/sdk/nodejs/dagger/dist/engine.js
@@ -48,13 +48,13 @@ export class Engine {
             });
             for (let i = 0; i < 360; i++) {
                 try {
-                    yield client.get("/");
+                    yield client.get("/query");
                 }
                 catch (e) {
                     yield new Promise((resolve) => setTimeout(resolve, 500));
                 }
             }
-            yield cb(new GraphQLClient(`http://localhost:${this.config.Port}`))
+            yield cb(new GraphQLClient(`http://localhost:${this.config.Port}/query`))
                 .catch((err) => __awaiter(this, void 0, void 0, function* () {
                 // FIXME:(sipsma) give the engine a sec to flush any progress logs on error
                 // Better solution is to send SIGTERM and have a handler in cloak engine that


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

We forget to re-build `dist` after updating the SDK here: https://github.com/dagger/dagger/issues/3091

This is needed for the todoapp because it uses js and imports this repo directly from git. If dist isn't updated then it will still use the old code from before. This is obviously a huge gotcha and really really easy to forget, so I'll create a followup to find a way of checking this in CI.