### PR TITLE
Add graphiql-explorer plugin to playground

### DIFF
--- a/playground/playground.go
+++ b/playground/playground.go
@@ -1,0 +1,161 @@
+package playground
+
+import (
+	"html/template"
+	"net/http"
+	"net/url"
+)
+
+var page = template.Must(template.New("graphiql").Parse(`{{ $tick := "` + "`" + `" }}
+<!DOCTYPE html>
+<html>
+  <head>
+  	<meta charset="utf-8">
+  	<title>{{.title}}</title>
+	<style>
+		body {
+			height: 100%;
+			margin: 0;
+			width: 100%;
+			overflow: hidden;
+		}
+
+		#graphiql {
+			height: 100vh;
+		}
+	</style>
+	<script
+		src="https://cdn.jsdelivr.net/npm/react@17/umd/react.production.min.js"
+		crossorigin="anonymous"
+	></script>
+	<script
+		src="https://cdn.jsdelivr.net/npm/react-dom@17/umd/react-dom.production.min.js"
+		crossorigin="anonymous"
+	></script>
+    <link
+		rel="stylesheet"
+		href="https://cdn.jsdelivr.net/npm/graphiql@{{.version}}/graphiql.min.css"
+		crossorigin="anonymous"
+	/>
+	<link
+      rel="stylesheet"
+	  crossorigin="anonymous"
+      href="https://cdn.jsdelivr.net/npm/@graphiql/plugin-explorer@{{.explorerVersion}}/dist/style.css"
+    />
+
+  </head>
+  <body>
+    <div id="graphiql">Loading...</div>
+
+	<script
+		src="https://cdn.jsdelivr.net/npm/graphiql@{{.version}}/graphiql.min.js"
+		crossorigin="anonymous"
+	></script>
+    <script
+      crossorigin="anonymous"
+      src="https://cdn.jsdelivr.net/npm/@graphiql/plugin-explorer@{{.explorerVersion}}/dist/graphiql-plugin-explorer.umd.js"
+    ></script>
+
+    <script>
+{{- if .endpointIsAbsolute}}
+      const url = {{.endpoint}};
+      const subscriptionUrl = {{.subscriptionEndpoint}};
+{{- else}}
+      const url = location.protocol + '//' + location.host + {{.endpoint}};
+      const wsProto = location.protocol == 'https:' ? 'wss:' : 'ws:';
+      const subscriptionUrl = wsProto + '//' + location.host + {{.endpoint}};
+{{- end}}
+     function GraphiQLWithExplorer() {
+	   var [query, setQuery] = React.useState(` + "`" + `
+# Welcome to Cloak's GraphQL explorer
+#
+# Keyboard shortcuts:
+#
+#   Prettify query:  Shift-Ctrl-P (or press the prettify button)
+#
+#  Merge fragments:  Shift-Ctrl-M (or press the merge button)
+#
+#        Run Query:  Ctrl-Enter (or press the play button)
+#
+#    Auto Complete:  Ctrl-Space (or just start typing)
+#
+
+# Here's a simple query to get you started, for more information visit
+# https:\/\/github.com/dagger/cloak/blob/main/docs/unxpq-introduction.mdx
+
+{
+  core {
+    image(ref: "alpine") {
+      exec(input: {args: ["apk", "add", "curl"]}){
+        fs {
+          exec(input: {args: ["curl", "https://dagger.io"]}) {
+            stdout(lines: 1)
+          }
+        }
+      }
+    }
+  }
+}
+
+` + "`" + `);
+	   var explorerPlugin = GraphiQLPluginExplorer.useExplorerPlugin({query, onEdit:setQuery});
+	   const fetcher = GraphiQL.createFetcher({ url, subscriptionUrl });
+       return React.createElement(GraphiQL, {
+         fetcher: fetcher,
+         defaultEditorToolsVisibility: true,
+		 query: query,
+		 onEditQuery: setQuery,
+         plugins: [explorerPlugin],
+       });
+     }
+
+     ReactDOM.render(
+       React.createElement(GraphiQLWithExplorer),
+       document.getElementById('graphiql'),
+     );
+    </script>
+  </body>
+</html>
+`))
+
+// Handler responsible for setting up the playground
+func Handler(title string, endpoint string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "text/html; charset=UTF-8")
+		err := page.Execute(w, map[string]interface{}{
+			"title":                title,
+			"endpoint":             endpoint,
+			"endpointIsAbsolute":   endpointHasScheme(endpoint),
+			"subscriptionEndpoint": getSubscriptionEndpoint(endpoint),
+			"version":              "2.0.7",
+			"explorerVersion":      "0.1.4",
+		})
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+// endpointHasScheme checks if the endpoint has a scheme.
+func endpointHasScheme(endpoint string) bool {
+	u, err := url.Parse(endpoint)
+	return err == nil && u.Scheme != ""
+}
+
+// getSubscriptionEndpoint returns the subscription endpoint for the given
+// endpoint if it is parsable as a URL, or an empty string.
+func getSubscriptionEndpoint(endpoint string) string {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return ""
+	}
+
+	switch u.Scheme {
+	case "https":
+		u.Scheme = "wss"
+	default:
+		u.Scheme = "ws"
+	}
+
+	return u.String()
+}

--- a/router/router.go
+++ b/router/router.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/99designs/gqlgen/graphql/playground"
+	"github.com/dagger/cloak/playground"
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/handler"
 )


### PR DESCRIPTION
Uses our own playground handler so we can add more plugins to graphiql.
This PR introduces the graphiql-explorer which simplifies the process
of discovering and crafting queries

Signed-off-by: Marcos Lilljedahl <marcosnils@gmail.com>
