### PR TITLE
WIP: multiplatform support

### DIFF
--- a/core/secret.schema.go
+++ b/core/secret.schema.go
@@ -74,15 +74,17 @@ func (s *secretSchema) Dependencies() []router.ExecutableSchema {
 }
 
 func (s *secretSchema) secret(p graphql.ResolveParams) (any, error) {
+	parent := router.Parent[struct{}](p.Source)
 	id := p.Args["id"].(string)
 	plaintext, err := s.secretStore.GetSecret(p.Context, id)
 	if err != nil {
 		return nil, fmt.Errorf("secret %s: %w", id, err)
 	}
-	return string(plaintext), nil
+	return router.WithVal(parent, string(plaintext)), nil
 }
 
 func (s *secretSchema) addSecret(p graphql.ResolveParams) (any, error) {
+	parent := router.Parent[struct{}](p.Source)
 	plaintext := p.Args["plaintext"].(string)
-	return s.secretStore.AddSecret(p.Context, []byte(plaintext)), nil
+	return router.WithVal(parent, s.secretStore.AddSecret(p.Context, []byte(plaintext))), nil
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -62,7 +62,7 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 		return err
 	}
 
-	platform, err := detectPlatform(ctx, c)
+	defaultPlatform, err := detectPlatform(ctx, c)
 	if err != nil {
 		return err
 	}
@@ -97,7 +97,7 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 		startOpts.ConfigPath = "./" + cloakYamlName
 	}
 
-	router := router.New()
+	router := router.New(*defaultPlatform)
 	secretStore := secret.NewStore()
 
 	socketProviders := MergedSocketProviders{
@@ -140,7 +140,6 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 				BKClient:      c,
 				SolveOpts:     solveOpts,
 				SolveCh:       ch,
-				Platform:      *platform,
 			})
 			if err != nil {
 				return nil, err

--- a/project/config.go
+++ b/project/config.go
@@ -5,34 +5,34 @@ import (
 )
 
 type Config struct {
-	Name         string        `yaml:"name"`
-	Dependencies []*Dependency `yaml:"dependencies,omitempty"`
-	Scripts      []*Script     `yaml:"scripts,omitempty"`
-	Extensions   []*Extension  `yaml:"extensions,omitempty"`
+	Name         string        `yaml:"name",json:"name"`
+	Dependencies []*Dependency `yaml:"dependencies,omitempty",json:"dependencies"`
+	Scripts      []*Script     `yaml:"scripts,omitempty",json:"scripts"`
+	Extensions   []*Extension  `yaml:"extensions,omitempty",json:"extensions"`
 }
 
 type Script struct {
-	Path string `yaml:"path"`
-	SDK  string `yaml:"sdk"`
+	Path string `yaml:"path",json:"path"`
+	SDK  string `yaml:"sdk",json:"sdk"`
 }
 
 type Extension struct {
-	Path string `yaml:"path"`
-	SDK  string `yaml:"sdk"`
+	Path string `yaml:"path",json:"path"`
+	SDK  string `yaml:"sdk",json:"sdk"`
 
 	// internal-only fields for tracking state
 	Schema string `yaml:"-"`
 }
 
 type Dependency struct {
-	Local string     `yaml:"local,omitempty"`
-	Git   *GitSource `yaml:"git,omitempty"`
+	Local string     `yaml:"local,omitempty",json:"local"`
+	Git   *GitSource `yaml:"git,omitempty",json:"git"`
 }
 
 type GitSource struct {
-	Remote string `yaml:"remote,omitempty"`
-	Ref    string `yaml:"ref,omitempty"`
-	Path   string `yaml:"path,omitempty"`
+	Remote string `yaml:"remote,omitempty",json:"remote"`
+	Ref    string `yaml:"ref,omitempty",json:"ref"`
+	Path   string `yaml:"path,omitempty",json:"path"`
 }
 
 func ParseConfig(data []byte) (*Config, error) {

--- a/project/project.go
+++ b/project/project.go
@@ -222,6 +222,8 @@ func (s *CompiledRemoteSchema) Dependencies() []router.ExecutableSchema {
 
 func (s *CompiledRemoteSchema) resolver(runtimeFS *filesystem.Filesystem) graphql.FieldResolveFn {
 	return func(p graphql.ResolveParams) (any, error) {
+		parent := router.Parent[any](p.Source)
+
 		pathArray := p.Info.Path.AsArray()
 		name := fmt.Sprintf("%+v", pathArray)
 
@@ -270,7 +272,7 @@ func (s *CompiledRemoteSchema) resolver(runtimeFS *filesystem.Filesystem) graphq
 		// to just use go type matching because the parent result may be a Filesystem struct or
 		// an untyped map[string]interface{}.
 		if p.Info.ParentType.Name() == "Filesystem" {
-			obj, err := filesystem.FromSource(p.Source)
+			obj, err := filesystem.FromSource(parent.Val)
 			if err != nil {
 				return nil, err
 			}
@@ -308,7 +310,7 @@ func (s *CompiledRemoteSchema) resolver(runtimeFS *filesystem.Filesystem) graphq
 		if err := json.Unmarshal(outputBytes, &output); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal output: %w", err)
 		}
-		return output, nil
+		return router.WithVal(parent, output), nil
 	}
 }
 

--- a/router/root.schema.go
+++ b/router/root.schema.go
@@ -1,5 +1,10 @@
 package router
 
+import (
+	"github.com/containerd/containerd/platforms"
+	"github.com/graphql-go/graphql"
+)
+
 type rootSchema struct {
 }
 
@@ -7,11 +12,14 @@ func (r *rootSchema) Name() string {
 	return "root"
 }
 
+// FIXME:(sipsma) platform should be enum, also this maybe should be in a different file
 func (r *rootSchema) Schema() string {
 	return `
-	type Query {
-	}
-	`
+type Query {
+	"TODO"
+	withPlatform(platform: String!): Query!
+}
+`
 }
 
 func (r *rootSchema) Operations() string {
@@ -19,9 +27,49 @@ func (r *rootSchema) Operations() string {
 }
 
 func (r *rootSchema) Resolvers() Resolvers {
-	return Resolvers{}
+	return Resolvers{
+		"Query": ObjectResolver{
+			"withPlatform": r.withPlatform,
+		},
+	}
 }
 
 func (r *rootSchema) Dependencies() []ExecutableSchema {
 	return nil
 }
+
+func (r *rootSchema) withPlatform(p graphql.ResolveParams) (any, error) {
+	parent := Parent[struct{}](p.Source)
+
+	specifier, _ := p.Args["platform"].(string)
+	if specifier != "" {
+		var err error
+		pl, err := platforms.Parse(specifier)
+		if err != nil {
+			return nil, err
+		}
+		parent.Platform = pl
+	}
+
+	return parent, nil
+}
+
+// TODO:
+// TODO:
+// TODO:
+// TODO: This is extremely promising!!
+/*
+func convert[A any, R any](f func(context.Context, A) (R, error)) graphql.FieldResolveFn {
+	return func(p graphql.ResolveParams) (any, error) {
+		bytes, err := json.Marshal(p.Args)
+		if err != nil {
+			return nil, err
+		}
+		var args A
+		if err := json.Unmarshal(bytes, &args); err != nil {
+			return nil, err
+		}
+		return f(p.Context, args)
+	}
+}
+*/


### PR DESCRIPTION
Signed-off-by: Erik Sipsma <erik@sipsma.dev>

This is highly WIP, the most invasive change has been updating the graphql server to enable passing ambient state through the execution graph, which is a lot less straightforward than it seems like it should be. The current solution is not coherent and broke some code that isn't in the path I need to test stuff currently.

However, in the middle of all this I think I discovered a clean approach, ***so please ignore all the weirdness with `Parent` for the moment if you are perusing, should be cleaned up soon.***

The actual multiplatform support has worked out nicely so far (fingers crossed). Starting out here with support for qemu-emulated execution and multiplatform image support. Cross-compilation is also going to be important to try out, but I suspect will be more straightforward.

The general idea here is that:
1. There's a top level field under query `withPlatform(platform: String!): Query!`, which enables you to wrap entire queries with a default platform setting. If you don't use this, platform defaults to the buildkit host platform.
   * Setting the platform applies to everything it can in buildkit (execops run with that platform, pulled images use it, etc.)
   * I haven't yet implemented passing this through when a non-core extension is invoked (i.e. if an extension sends its own query, it will default to the platform in its ambient context), but that will be a straightforward addition on top of the idea here.
   * Extensions will also be able to override the platform too when making their own queries. One example of where this may be helpful is if an extension knows that it want something to execute using the host platform (i.e. it's invoking something that uses cross compilation)
   * The final piece of the puzzle is that if you do something that creates a new layer on top of an existing layer, the platform needs to be inherited. This is the behavior of `client/llb` already, but I need to make sure it still works across a marshal/unmarshal cycle (if it doesn't it should be trivial to recreate that behavior)
2. For multiplatform exports
   * I just added a top-level `pushMultiplatformImage` field to `core` for now as a temporary solution. It's okay but a likely better approach would be to create some abstraction that lets you bundle different platform versions of a filesystem together and then add a `pushImage` field to that. That will make sense to do as part of the upcoming overall API refactor. 
   * It's also important that you can individually reference platform specific versions of a given filesystem (i.e. they don't *always* have to be bundled together). This enables use cases like local exports where you may want to export binaries built for each platform to different local directories.

Overall, the above sounds really complicated, and to extent that's inherent to multiplatform, but if my imagination is correct it should work out so that multiplatform config usually does what you want by default and you only have to think hard about it when you're doing something inherently complicated.

The only way to verify that will be to try out various scenarios and ensure they go smoothly (started describing some of those [here](https://github.com/dagger/dagger/issues/3064)), so that will be my main focus besides just cleaning up the code here and adding the final missing features.