### PR TITLE
propagate image env to `image.exec`

### DIFF
--- a/core/integration/core.schema_test.go
+++ b/core/integration/core.schema_test.go
@@ -44,6 +44,60 @@ func TestCoreImage(t *testing.T) {
 	require.Equal(t, res.Core.Image.FS.File, "3.16.2\n")
 }
 
+func TestCoreImageConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("propagates env", func(t *testing.T) {
+		res := struct {
+			Core struct {
+				Image struct {
+					Exec struct {
+						Stdout string
+					}
+				}
+			}
+		}{}
+
+		err := testutil.Query(
+			`{
+			core {
+				image(ref: "golang:1.19") {
+					exec(input: {args: ["env"]}) {
+						stdout
+					}
+				}
+			}
+		}`, &res, nil)
+		require.NoError(t, err)
+		require.Contains(t, res.Core.Image.Exec.Stdout, "GOLANG_VERSION=")
+	})
+
+	t.Run("exec env overrides", func(t *testing.T) {
+		res := struct {
+			Core struct {
+				Image struct {
+					Exec struct {
+						Stdout string
+					}
+				}
+			}
+		}{}
+
+		err := testutil.Query(
+			`{
+			core {
+				image(ref: "golang:1.19") {
+					exec(input: {args: ["env"], env: [{name: "GOLANG_VERSION", value: "banana"}]}) {
+						stdout
+					}
+				}
+			}
+		}`, &res, nil)
+		require.NoError(t, err)
+		require.Contains(t, res.Core.Image.Exec.Stdout, "GOLANG_VERSION=banana")
+	})
+}
+
 func TestCoreGit(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
fixes dagger/dagger#3066 

**This change is backwards-incompatible.** I've also got a few `TODO`s which I'd love feedback on. This is my first time touching this area so please pick it apart or let me know of alternatives! 🙇‍♂️

* Changes `core.image()` to return an `Image` instead of a `Filesystem`.
* An `Image` is a `Filesystem` plus an `ExecInput` derived from the OCI image config.
* `Image` has its own `exec()` that combines the two, with the inputs to `exec()` overriding.
* Currently only env vars are propagated. I think we need to think about at least a few of the other values to decide how/whether they should be propagated.

The new `Image` type re-uses the existing `ExecInput` type rather than exposing OCI image config, but I don't feel strongly about that. I figured it would be easier to stick with the current domain of types. Maybe there'll some occasion where we come up with an `Image` and initial exec config some other way?

### alternatives considered

* I initially tried just using `llb.WithMetaResolver(r.gw)` and even `(llb.State).WithImageConfig` but the image config data doesn't end up in the marshaled LLB definition. :slightly_frowning_face: