### PR TITLE
Add links to extensions in docs

### DIFF
--- a/docs/unxpq-introduction.md
+++ b/docs/unxpq-introduction.md
@@ -97,6 +97,6 @@ end
 
 ### Available Extensions
 
-- [Vercel](https://github.com/slumbering/dagger-vercel)
-- [Terraform](https://github.com/kpenfound/dagger-terraform)
-- [Rails](https://github.com/kpenfound/dagger-rails)
+* [Vercel](https://github.com/slumbering/dagger-vercel)
+* [Terraform](https://github.com/kpenfound/dagger-terraform)
+* [Rails](https://github.com/kpenfound/dagger-rails)


### PR DESCRIPTION
Signed-off-by: kpenfound <kyle@dagger.io>

Just added links to our first extensions in the introduction page after the Extensions section. I think eventually this should be it's own page, but for now this location seemed appropriate.